### PR TITLE
Add: 認知症当事者のナラティブに基づくPX体験空間の設計と実装 by 廣部敬太

### DIFF
--- a/content/publication/20240913-vrsj-keita-hirobe/_index.en.md
+++ b/content/publication/20240913-vrsj-keita-hirobe/_index.en.md
@@ -1,0 +1,57 @@
+---
+title: "Design and Implementation of PX Experience Spaces Based on the Narratives of People with Dementia"
+authors:
+  - keita-hirobe
+  - atsushi-omata 
+  - Takuhiro Mizuno
+  - Yujun Murakami
+  - admin 
+
+date: '2024-09-13T00:00:00Z' # 発表した日付 or 出版された日付
+doi: ""
+publishDate: '2024-09-13T00:00:00Z' # 発表した日付 or 出版された日付
+
+# 出版タイプ（↓の表参照）
+publication_types:
+  - paper-conference
+
+# カテゴリタイプ（↓の表参照）
+categories:
+  - Domestic Conference
+  - Poster Presentation
+
+# Publication name and optional abbreviated publication name.
+publication: In *The 29th Annual Conference of the Virtual Reality Society of Japan*
+publication_short: In *VRSJ 2024*
+
+abstract: Because the relationship between the manifestations of symptoms and causes of dementia is diverse, skills to understand the cognitive perspectives of people with dementia are important, and the experiential images of the narratives need to be supplemented. In this study, we constructed a PX experience platform that enables users to experience the patient experience (PX) in VR based on the narratives of people with dementia, and investigated the usefulness of this platform. This platform enables the user to experience various cognitive impairments from a first-person perspective, control the impairments and environment, and share the space with many people, enabling the user to experience cognitive activities while comparing them with healthy people. As a result of using the system for the general public, it was suggested that sharing the experience with other learners may lead to a better understanding of dementia, and that the experience by people with dementia may deepen their understanding of cognitive activities.
+   
+summary: Presentation at the 29th Annual Conference of the Virtual Reality Society of Japan (VRSJ).
+
+tags:
+  - metaverse
+  - VR
+  - Patient Experience
+
+feature: false
+
+links:
+- name: The 29th Annual Conference of the Virtual Reality Society of Japan
+  url: https://conference.vrsj.org/ac2024/index.html
+# プロジェクト名はprojectsのフォルダ名と一致させる（例：care-dx）
+projects:
+  - metaverse-px
+
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: false
+url_pdf: "https://conference.vrsj.org/ac2024/program/doc/3A1-07.pdf"
+url_code: ""
+url_dataset: ""
+url_poster: ""
+url_slides: ""
+url_video: ""
+url_source: ""
+note: ""
+---

--- a/content/publication/20240913-vrsj-keita-hirobe/_index.ja.md
+++ b/content/publication/20240913-vrsj-keita-hirobe/_index.ja.md
@@ -1,0 +1,57 @@
+---
+title: "認知症当事者のナラティブに基づくPX体験空間の設計と実装"
+authors:
+  - keita-hirobe
+  - atsushi-omata 
+  - 水野 拓宏
+  - 村上 佑順
+  - admin 
+
+date: '2024-09-13T00:00:00Z' # 発表した日付 or 出版された日付
+doi: ""
+publishDate: '2024-09-13T00:00:00Z' # 発表した日付 or 出版された日付
+
+# 出版タイプ（↓の表参照）
+publication_types:
+  - paper-conference
+
+# カテゴリタイプ（↓の表参照）
+categories:
+  - Domestic Conference
+  - Poster Presentation
+
+# Publication name and optional abbreviated publication name.
+publication: In *第29回日本バーチャルリアリティ学会大会*
+publication_short: In *VRSJ 2024*
+
+abstract: 認知症は表出化する症状と原因の関係が多様であるため，認知症当事者の認知的視点を理解するスキルが重要であり，ナラティブの経験的イメージの補完が必要である．本研究では，認知症当事者のナラティブを基に，患者体験（PX）をVRで体験することが可能なPX体験プラットフォームを構築し，その有用性を検討した．本プラットフォームは，多様な認知的障害を一人称視点で体験し，障害や環境をコントロールする機能や多人数で空間を共有する機能があり，認知的な活動を健常者と比較しながら体験することが可能である．一般市民に対して活用した結果，学習者同士が共有することで認知症の理解に繋がる可能性や，認知症当事者が体験することによって認知的活動の理解を深めていけることが示唆された．
+   
+summary: 第29回日本バーチャルリアリティ学会大会にて発表しました．
+
+tags:
+  - metaverse
+  - VR
+  - Patient Experience
+
+feature: false
+
+links:
+- name: 第29回日本バーチャルリアリティ学会大会
+  url: https://conference.vrsj.org/ac2024/index.html
+# プロジェクト名はprojectsのフォルダ名と一致させる（例：care-dx）
+projects:
+  - metaverse-px
+
+image:
+  caption: ""
+  focal_point: ""
+  preview_only: false
+url_pdf: "https://conference.vrsj.org/ac2024/program/doc/3A1-07.pdf"
+url_code: ""
+url_dataset: ""
+url_poster: ""
+url_slides: ""
+url_video: ""
+url_source: ""
+note: ""
+---


### PR DESCRIPTION
### 概要

"認知症当事者のナラティブに基づくPX体験空間の設計と実装"に関する情報を、publication ディレクトリに追加しました。

### 変更内容

- content/publication/配下に新しいディレクトリ（20240913-vrsj-keita-hirobe）を作成
- `index.md` にタイトル、著者、要旨、PDFリンクなどを記載
- 日本語と英語の要約を含む構成

### 補足事項

- 外部リンク（PDF, 学会ホームページ）は正しく動作確認済み